### PR TITLE
Add CI: tests on a clean runner, and guard the add-on's server pin

### DIFF
--- a/.github/workflows/addon.yml
+++ b/.github/workflows/addon.yml
@@ -1,0 +1,64 @@
+name: Add-on
+
+# The add-on arrived as 25 files that nothing validated. Two things can break it
+# without anyone noticing until a user's install fails:
+#
+#   1. The Dockerfile stops building.
+#   2. HOME_MIND_REF points at a tag that does not exist. The server is fetched
+#      from codeload by tag, so an untagged version cannot be built at all.
+on:
+  push:
+    branches: [main]
+    paths: ["home_mind/**", "src/home-mind-server/package.json", ".github/workflows/addon.yml"]
+  pull_request:
+    paths: ["home_mind/**", "src/home-mind-server/package.json", ".github/workflows/addon.yml"]
+
+jobs:
+  pin:
+    name: Server pin points somewhere real
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: HOME_MIND_REF matches package.json and the tag exists
+        run: |
+          set -euo pipefail
+          server=$(node -p "require('./src/home-mind-server/package.json').version")
+          ref=$(sed -n 's/^ARG HOME_MIND_REF=\(.*\)$/\1/p' home_mind/Dockerfile)
+          echo "server package.json : $server"
+          echo "HOME_MIND_REF       : $ref"
+
+          if [ "$ref" != "v$server" ]; then
+            echo "::error file=home_mind/Dockerfile::HOME_MIND_REF is $ref but the server is $server. The add-on would build an old server. Bump HOME_MIND_REF to v$server."
+            exit 1
+          fi
+
+          # The tag has to exist before the add-on can reference it, so a bump
+          # that runs ahead of the release is caught here rather than on a
+          # user's machine. Order: tag first, then point the add-on at it.
+          if ! git ls-remote --exit-code --tags origin "refs/tags/$ref" >/dev/null 2>&1; then
+            echo "::error file=home_mind/Dockerfile::Tag $ref does not exist on origin, so this add-on cannot be built. Tag and push $ref first, then bump the add-on."
+            exit 1
+          fi
+          echo "OK: $ref exists and matches the server version."
+
+  build:
+    name: Image builds
+    runs-on: ubuntu-latest
+    needs: pin
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+
+      # Build only, never push. Users build this add-on on their own machine,
+      # so there is no registry to publish to and nothing to sign.
+      - uses: docker/build-push-action@v6
+        with:
+          context: home_mind
+          push: false
+          build-args: |
+            BUILD_FROM=ghcr.io/home-assistant/amd64-base-debian:bookworm-2026.02.0
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,32 @@
+name: Test
+
+# The only gate this project has ever had is a developer remembering to run
+# `npm test`. That is thinner than it looks: the sqlite tests need a compiled
+# native module, and a machine that blocks install scripts skips ten of them
+# without saying so. A clean runner does not.
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: src/home-mind-server
+    steps:
+      - uses: actions/checkout@v4
+
+      # Node 20 on purpose: it is what home_mind/Dockerfile builds with, so CI
+      # tests the runtime that actually ships rather than whatever is newest.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: src/home-mind-server/package-lock.json
+
+      - run: npm ci
+      - run: npm run typecheck
+      - run: npm test
+      - run: npm run build


### PR DESCRIPTION
Two workflows. Neither pushes anything anywhere.

## Why now

Going without CI was defensible while the only artifact was source. Two things changed today.

**The one gate we had has a hole in it.** `CLAUDE.md` says `npm test` is "the only gate; there is no CI to catch a mistake". On this machine that gate reports **10 failures out of 276**, all in `conversation-sqlite.test.ts`, and none of them are code bugs: the tests need a compiled native module, and npm here is configured to block install scripts. So ten tests have not run in a while, silently. A clean runner compiles it and runs them.

**The add-on is 25 files that nothing validates.** And its Dockerfile fetches the server from codeload *by git tag*, which means a `HOME_MIND_REF` pointing at a tag that does not exist makes the add-on unbuildable, with the first symptom being a user watching an install fail.

## What the jobs do

**`Test`** — `npm ci`, `typecheck`, `test`, `build`. Node pinned to **20**, matching `home_mind/Dockerfile`, so CI exercises the runtime that actually ships rather than whatever is newest.

**`Add-on`** — runs only when `home_mind/**` or the server `package.json` changes.

- **`pin`** checks `HOME_MIND_REF` equals `v<package.json version>`, so the add-on cannot quietly build an old server, and that the tag really is on origin, so a bump running ahead of a release is caught here. Verified against three cases before committing: current state passes; server bumped with the add-on left behind fails; add-on pointing at an untagged version fails.
- **`build`** builds the image. `push: false` — users build this add-on themselves, so there is no registry and nothing to sign.

## One thing deliberately left out

**No lint step.** `npm run lint` calls `eslint`, which is not in `devDependencies`, has no config file, and is not installed. The script has never worked, and `CLAUDE.md` documents it as if it does. Adding eslint to an existing codebase belongs in its own change, not smuggled into a CI PR. Worth deciding separately whether to wire it up properly or drop the script.

## Honest limitation

I could not verify the sqlite tests pass locally, because this machine blocks the native build. Pinning Node 20 makes that very likely, since it is the version the Dockerfile uses, but the first run on this PR is the real proof.